### PR TITLE
Branding: use "Aspire" instead of ".NET Aspire"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Create and connect to Azure Storage services using .NET Aspire
+# Create and connect to Azure Storage services using Aspire
 
-`dotnet-aspire-connect-storage` is a demo project that shows how to create an Azure storage account using the [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/overview)(azd), and how to connect to it locally using a .NET Aspire app.
+`dotnet-aspire-connect-storage` is a demo project that shows how to create an Azure storage account using the [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/overview)(azd), and how to connect to it locally using an Aspire app.
 
 ## Prerequisites
 

--- a/src/AspireStorage/AspireStorage.AppHost/AspireStorage.AppHost.csproj
+++ b/src/AspireStorage/AspireStorage.AppHost/AspireStorage.AppHost.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\AspireStorage.WorkerService\AspireStorage.WorkerService.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
   </ItemGroup>
 </Project>

--- a/src/AspireStorage/AspireStorage.ServiceDefaults/Extensions.cs
+++ b/src/AspireStorage/AspireStorage.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/AspireStorage/AspireStorage.Web/AspireStorage.Web.csproj
+++ b/src/AspireStorage/AspireStorage.Web/AspireStorage.Web.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="9.0.0" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="9.0.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.6" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
   </ItemGroup>
 
 </Project>

--- a/src/AspireStorage/AspireStorage.WorkerService/AspireStorage.WorkerService.csproj
+++ b/src/AspireStorage/AspireStorage.WorkerService/AspireStorage.WorkerService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="9.0.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Use "Aspire" branding and update to the latest release (13.4.6)

Aspire was rebranded from **".NET Aspire"** to simply **"Aspire"**, and the latest release is **13.4.6** ([aspire.dev](https://aspire.dev)). This PR updates this sample accordingly.

### Branding
- Replaced `.NET Aspire` → `Aspire` in prose/docs.
- **Left unchanged** references tied to a specific older release (e.g. ".NET Aspire 9.4", ".NET Aspire 8.0"), since that was the product name at that version. Historical notes/changelogs are also untouched. `ASP.NET` text is unaffected.

### Versions
- Bumped official `Aspire.*` packages and `Aspire.AppHost.Sdk` to **13.4.6**.
- Preview-only packages (`Aspire.Azure.AI.OpenAI`, `Aspire.Azure.AI.Inference`) → `13.4.6-preview.1.26319.6`.
- Left as-is: `Aspire.Hosting.NodeJs` (no 13.x release), `CommunityToolkit.Aspire.*` (separate versioning).

> Opened as a **draft** for maintainer review. A cross-major bump may require small code adjustments to build — please validate. Part of a coordinated branding + version refresh.
